### PR TITLE
Add KubeArmor AWS credentials block detection

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -17,6 +17,12 @@ jobs:
           sudo wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq
           sudo chmod +x /usr/bin/yq
 
+      - name: Make all scripts executable
+        run: |
+          chmod +x ./scripts/*.sh
+          chmod +x ./lifecycle/*.sh
+          chmod +x ./simulations/**/*.sh || true
+
       - name: Run registry validator
         run: ./scripts/validate-registry.sh
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -19,9 +19,9 @@ jobs:
 
       - name: Make all scripts executable
         run: |
-          chmod +x ./scripts/*.sh
-          chmod +x ./lifecycle/*.sh
-          chmod +x ./simulations/**/*.sh || true
+          find ./scripts -type f -name "*.sh" -exec chmod +x {} \;
+          find ./lifecycle -type f -name "*.sh" -exec chmod +x {} \;
+          find ./simulations -type f -name "*.sh" -exec chmod +x {} \;
 
       - name: Run registry validator
         run: ./scripts/validate-registry.sh

--- a/detections/_registry.yaml
+++ b/detections/_registry.yaml
@@ -2,7 +2,7 @@
   tool: falco
   source: syscall
   category: toctou
-  rule: rules/falco/toctou-configmap-detect.yaml
+  rule: rules/falco/tocou/toctou-configmap-detect.yaml
   sim: simulations/falco/toctou/simulate-detect.sh
   mitre: T1203
   doc_section: detections/toctou.md

--- a/detections/_registry.yaml
+++ b/detections/_registry.yaml
@@ -2,7 +2,7 @@
   tool: falco
   source: syscall
   category: toctou
-  rule: rules/falco/tocou/toctou-configmap-detect.yaml
+  rule: rules/falco/toctou/toctou-configmap-detect.yaml
   sim: simulations/falco/toctou/simulate-detect.sh
   mitre: T1203
   doc_section: detections/toctou.md

--- a/detections/_registry.yaml
+++ b/detections/_registry.yaml
@@ -1,8 +1,8 @@
-- name: toctou-configmap-write
+- name: toctou-configmap-detect
   tool: falco
   source: syscall
   category: toctou
-  rule: rules/falco/toctou-configmap-write.yaml
+  rule: rules/falco/toctou-configmap-detect.yaml
   sim: simulations/falco/toctou/simulate-detect.sh
   mitre: T1203
   doc_section: detections/toctou.md

--- a/detections/_registry.yaml
+++ b/detections/_registry.yaml
@@ -32,3 +32,10 @@
   sim: simulations/falco/rbac/simulate-clusterrole-escalation.sh
   validate: clusterrolebinding
   mitre: T1068
+- name: kubearmor-aws-credential-block
+  tool: kubearmor
+  category: creds
+  rule: rules/kubearmor/creds/block-aws-credential-access.yaml
+  sim: simulations/kubearmor/creds/simulate-block-aws-credential-access.sh
+  mitre: [T1552]
+  validate: true

--- a/detections/_registry.yaml
+++ b/detections/_registry.yaml
@@ -20,7 +20,7 @@
   tool: falco
   source: k8s_audit
   category: rbac
-  rule: rules/falco/rbac/rbac-api-misuse.yaml
+  rule: rules/falco/rbac/rbac-api-misuse-detect.yaml
   sim: simulations/falco/rbac/simulate-rbac-abuse.sh
   mitre: T1552.004
   doc_section: detections/rbac.md

--- a/rules/kubearmor/creds/block-aws-credential-access.yaml
+++ b/rules/kubearmor/creds/block-aws-credential-access.yaml
@@ -1,0 +1,16 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: block-aws-credential-access
+  namespace: default
+spec:
+  severity: 5
+  message: "Blocked access to AWS credentials"
+  selector:
+    matchLabels:
+      app: demo-kubearmor
+  file:
+    matchDirectories:
+      - dir: /root/.aws/
+        recursive: true
+  action: Block

--- a/simulations/kubearmor/creds/simulate-block-aws-credential-access.sh
+++ b/simulations/kubearmor/creds/simulate-block-aws-credential-access.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+POD_NAME=aws-creds-block-test
+POLICY=block-aws-credential-access
+
+echo "[*] Cleaning up any existing pod and policy..."
+kubectl delete pod $POD_NAME --ignore-not-found
+kubectl delete ksp $POLICY -n default --ignore-not-found
+
+echo "[*] Applying KubeArmor policy..."
+kubectl apply -f rules/kubearmor/creds/block-aws-credential-access.yaml
+sleep 3
+
+echo "[*] Launching test pod with fake AWS credentials..."
+kubectl run $POD_NAME \
+  --image=busybox \
+  --labels=app=demo-kubearmor \
+  --restart=Never \
+  --overrides='
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "demo-container",
+          "image": "busybox",
+          "command": ["sleep", "60"],
+          "volumeMounts": [
+            {
+              "mountPath": "/root/.aws",
+              "name": "aws-creds"
+            }
+          ]
+        }
+      ],
+      "volumes": [
+        {
+          "name": "aws-creds",
+          "emptyDir": {}
+        }
+      ]
+    }
+  }'
+
+echo "[*] Waiting for pod to be ready..."
+kubectl wait --for=condition=Ready pod/$POD_NAME --timeout=20s
+
+echo "[*] Attempting to access /root/.aws/credentials (should be blocked)..."
+kubectl exec $POD_NAME -- sh -c 'touch /root/.aws/credentials' || echo "✅ Block confirmed."
+
+echo "[*] Cleaning up..."
+kubectl delete pod $POD_NAME --ignore-not-found
+kubectl delete ksp $POLICY -n default --ignore-not-found


### PR DESCRIPTION
This PR adds a KubeArmor rule and simulation for blocking access to AWS credentials (/root/.aws). Includes policy, sim script, and registry entry. Aligned with MITRE T1552.